### PR TITLE
Added Canvas 1.6.x and 2.x compatibility

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -5,19 +5,53 @@ try {
     Canvas = require('canvas');
 }
 
+/**
+ * This variable helps Canvas-Constructor to identify if the version
+ * of canvas is older than 2.0.0 (new Canvas()) or newer (Canvas.createCanvas).
+ */
+const isNotConstructor = typeof Canvas.createCanvas === 'function';
+
 class CanvasConstructor {
 
     /**
      * Initialize canvas-constructor
-     * @param {number} width       The canvas' width in pixels.
-     * @param {number} height      The canvas' height in pixels.
-     * @param {('pdf'|'svg')} type The canvas type.
+     * @param {number} width The canvas' width in pixels.
+     * @param {number} height The canvas' height in pixels.
+     * @param {('pdf'|'svg')} [type] The canvas type.
      */
     constructor(width, height, type) {
-        this.canvas = Canvas.createCanvas(width, height, type);
+        /**
+         * The constructed Canvas
+         * @since 0.0.1
+         * @type {Canvas}
+         * @private
+         */
+        this.canvas = isNotConstructor ?
+            // node-canvas >2.0.0
+            Canvas.createCanvas(width, height, type) :
+            // node-canvas <2.0.0
+            new Canvas(width, height);
+
+        /**
+         * The 2D context for this canvas
+         * @since 0.0.1
+         * @type {CanvasRenderingContext2D}
+         * @private
+         */
         this.context = this.canvas.getContext('2d');
 
+        /**
+         * The image width of this canvas
+         * @since 0.0.1
+         * @type {number}
+         */
         this.width = width;
+
+        /**
+         * The image height of this canvas
+         * @since 0.0.1
+         * @type {number}
+         */
         this.height = height;
     }
 
@@ -1182,7 +1216,20 @@ class CanvasConstructor {
     }
 
     /**
-     * Register a new font.
+     * Register a new font (Canvas 1.6.x).
+     * @param {string} path   The path for the font.
+     * @param {string} family The font's family name.
+     * @returns {CanvasConstructor}
+     * @chainable
+     */
+    addTextFont(path, family) {
+        if (isNotConstructor) CanvasConstructor.registerFont(path, family);
+        else this.context.addFont(new Canvas.Font(family, path));
+        return this;
+    }
+
+    /**
+     * Register a new font (Canvas 2.x).
      * @param {string} path   The path for the font.
      * @param {string} family The font's family name.
      * @returns {CanvasConstructor}

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -15,6 +15,9 @@ declare module 'canvas-constructor' {
         public constructor(width: number, height: number, type?: CanvasType);
         public canvas: HTMLCanvasElement;
         public context: CanvasRenderingContext2D;
+        public width: number;
+        public heigth: number;
+        public readonly lineDash: number[];
 
         public changeCanvasSize(width?: number, height?: number): this;
         public changeCanvasWidth(width: number): this;
@@ -90,9 +93,9 @@ declare module 'canvas-constructor' {
         public clearCircle(x: number, y: number, radius: number, start?: number, angle?: number): this;
         public clearPixels(x?: number, y?: number, width?: number, height?: number): this;
         public getLineDash(): number[];
-        public readonly lineDash: number[];
         public isPointInPath(x: number, y: number, fillRule: fillRuleType): boolean;
         public isPointInStroke(x: number, y: number): boolean;
+        public addTextFont(path: string, family: string | fontFaceType): this;
 
         public process(fn: (canvas: this) => void): this;
 


### PR DESCRIPTION
One of the gotchas from this package is that you needed canvas-constructor stable for node-canvas stable, and canvas-constructor master for node-canvas master. However, this is against the initial idea of this package.

This change allows users to use any of both versions with the same version of canvas-constructor. This way, it is much easier to install.

This PR also fixes some typings and adds documentation to CanvasConstructor's properties.