### PR TITLE
Implement toDataURL method

### DIFF
--- a/src/canvas.js
+++ b/src/canvas.js
@@ -1211,6 +1211,29 @@ class CanvasConstructor {
         }));
     }
 
+    /**
+     * Render the canvas into a Data URL.
+     * @param {string} type the standard MIME type for the image format to return. If you do not specify this parameter, the default value is PNG.
+     * @param {any[]} args Extra arguments
+     * @returns {string}
+     * @see https://github.com/Automattic/node-canvas#canvastodataurl-sync-and-async
+     */
+    toDataURL(type, ...args) {
+        return this.canvas.toDataURL(type, ...args);
+    }
+
+    /**
+     * Render the canvas into a Data URL using a Promise.
+     * @param {string} type the standard MIME type for the image format to return. If you do not specify this parameter, the default value is PNG.
+     * @returns {Promise<string>}
+     */
+    toDataURLAsync(type) {
+        return new Promise((resolve, reject) => this.canvas.toDataURL(type, (err, url) => {
+            if (err) reject(err);
+            else resolve(url);
+        }));
+    }
+
     static getCanvas() {
         return Canvas;
     }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -101,6 +101,8 @@ declare module 'canvas-constructor' {
 
         public toBuffer(options?: Object): Buffer;
         public toBufferAsync(): Promise<Buffer>;
+        public toDataURL(type: string, ...args: any[]): string;
+        public toDataURLAsync(type: string): Promise<string>;
 
         public static getCanvas(): NodeCanvas;
         public static registerFont(path: string, family: string | fontFaceType);


### PR DESCRIPTION
In this PR I try my best to implement toDataURl.. this follows the same typings as HTMLCanvasElement for toDataURL and the reason I link to node-canvas for toDataURL is that it offers more options as well it follows the spec. toDataURLasync was to be consistent. Welcome to reviews!