### PR TITLE
feat: Add `'png'` as a supported type in CanvasType

### DIFF
--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -140,7 +140,7 @@ declare module 'canvas-constructor' {
 		bl?: number;
 	}
 
-	export type CanvasType = 'pdf' | 'svg';
+	export type CanvasType = 'pdf' | 'svg' | 'png';
 
 	export type FillRuleType = 'nonzero' | 'evenodd';
 


### PR DESCRIPTION
As canvas has the functionality to export to png, it would be good to also allow it in canvas-constructor. 